### PR TITLE
feat: implement login and session management

### DIFF
--- a/drizzle/0002_high_tombstone.sql
+++ b/drizzle/0002_high_tombstone.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `sessions` (
+	`id` serial AUTO_INCREMENT NOT NULL,
+	`token` varchar(255) NOT NULL,
+	`user_id` int NOT NULL,
+	`created_at` timestamp DEFAULT (now()),
+	CONSTRAINT `sessions_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+ALTER TABLE `sessions` ADD CONSTRAINT `sessions_user_id_users_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE no action ON UPDATE no action;

--- a/drizzle/0003_smart_true_believers.sql
+++ b/drizzle/0003_smart_true_believers.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `sessions` MODIFY COLUMN `user_id` bigint unsigned NOT NULL;

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,138 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "041bcb61-355a-40c4-88af-35f6e9564a68",
+  "prevId": "ab2d95c0-b743-4ddd-acf3-2b65f44a1aaf",
+  "tables": {
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "sessions_id": {
+          "name": "sessions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "users_id": {
+          "name": "users_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,138 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "cfb73f5d-1129-4fc4-9df3-4d1be80e0a6b",
+  "prevId": "041bcb61-355a-40c4-88af-35f6e9564a68",
+  "tables": {
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint unsigned",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "sessions_id": {
+          "name": "sessions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "users_id": {
+          "name": "users_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,20 @@
       "when": 1774928324829,
       "tag": "0001_strange_mastermind",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "5",
+      "when": 1774933955818,
+      "tag": "0002_high_tombstone",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "5",
+      "when": 1774933967585,
+      "tag": "0003_smart_true_believers",
+      "breakpoints": true
     }
   ]
 }

--- a/issue.md
+++ b/issue.md
@@ -1,0 +1,84 @@
+# Fitur: Login User dan Manajemen Session
+
+## Deskripsi Tugas
+Tugas ini bertujuan untuk mengimplementasikan fitur Otentikasi/Login. Kita perlu membuat tabel database untuk mencatat sesi (session) pengguna serta menyediakan satu endpoint API baru untuk memproses login.
+
+## Detail Persyaratan (Requirements)
+
+1. **Pembuatan Tabel `sessions` di Database**:
+   - `id`: tipe *integer*, *auto increment*, *primary key*.
+   - `token`: tipe *varchar(255)*, *not null*. Akan berisi nilai unik (UUID) token otentikasi.
+   - `user_id`: tipe *integer*, berfungsi sebagai *foreign key* yang merujuk ke tabel `users`.
+   - `created_at`: tipe *timestamp*, *default current_timestamp*.
+
+2. **Spesifikasi Endpoint API Login**:
+   - **Method & URL**: `POST /api/users/login`
+   - **Request Body (JSON)**:
+     ```json
+     {
+         "email": "user@email.com",
+         "password": "plain password"
+     }
+     ```
+   - **Response Berhasil** (HTTP Status: 200 OK):
+     ```json
+     {
+         "status": 200,
+         "message": "user logged in successfully",
+         "data": {
+             "name": "sample user",
+             "token": "uuid-token"
+         }
+     }
+     ```
+   - **Response Gagal** (Kredensial tidak valid) (HTTP Status: 400 Bad Request):
+     ```json
+     {
+         "status": 400,  
+         "message": "incorrect email or password combination",
+         "data": null
+     }
+     ```
+
+3. **Standar Struktur Folder**:
+   - Seluruh logika routing ElysiaJS tetap ditempatkan di dalam folder `src/routes`. Gunakan/lanjutkan file `users-route.ts`.
+   - Seluruh *business logic* tetap ditempatkan di dalam folder `src/services`. Gunakan/lanjutkan file `users-service.ts`.
+
+---
+
+## Panduan Implementasi (Step-by-Step Guide)
+
+Bagian ini ditujukan kepada programmer atau agen AI yang akan melanjutkan tugas ini.
+
+### Langkah 1: Update Skema Database
+- Buka file `src/db/schema.ts`.
+- Buat pendefinisian tabel baru `sessions` menggunakan format Drizzle ORM (`mysqlTable`), pastikan tipe datanya selaras dengan pesyaratan (gunakan referensi untuk foreign key `user_id`).
+- Setelah tersimpan, jalankan Drizzle Kit untuk menerapkan ke MySQL:
+  1. `bunx drizzle-kit generate`
+  2. `bunx drizzle-kit push`
+
+### Langkah 2: Buat Logika Service (Business Logic)
+- Buka file `src/services/users-service.ts`.
+- Tambahkan fungsi asinkron (misal: `loginUser`) yang menerima `email` dan `password`.
+- **Alur kerja di dalam fungsi**:
+  1. Cari data *user* berdasarkan `email` di database.
+  2. Jika user tidak ditemukan, *throw Error* dengan pesan "incorrect email or password combination".
+  3. Jika ditemukan, gunakan metode `bcrypt.compare` untuk mencocokkan `password` (input) dengan password hashing di database.
+  4. Jika tidak cocok, *throw Error* dengan pesan yang *sama seperti langkah 2* (penting agar tidak membocorkan informasi apakah email ada atau tidak).
+  5. Jika cocok, *generate* string UUID acak (contoh: pakai `crypto.randomUUID()`).
+  6. Masukkan (`insert`) baris baru ke tabel `sessions` menggunakan Drizzle. Berisi `token` UUID tersebut dan `user_id` yang login.
+  7. Return tipe objek yang memiliki `name` dan `token` saja.
+
+### Langkah 3: Tambahkan Routing (Routes)
+- Buka file `src/routes/users-route.ts`.
+- Di bawah routing `POST /` (registrasi), tambahkan _chain_ method `.post('/login', ...)` pada grup `/users`.
+- Konfigurasikan struktur *body validation* Elysia (via `t.Object`) yang mewajibkan adanya tipe `email` (string) dan `password` (string).
+- Di dalam _handler_ fungsi:
+  1. Ekstrak *body* dan lemparkan datanya ke konfirmasi dari `loginUser` pada berkas `users-service`.
+  2. Dalam skenario `try` (Sukses): Atur `set.status = 200` lalu berikan respons JSON sesuaikan dengan contoh di Requirement 2 di atas.
+  3. Dalam skenario `catch` (Gagal): Atur `set.status = 400` dan respons JSON error yang format datanya diambil dari pesan error yang di-_throw_.
+
+### Langkah 4: Pengujian (Verification)
+- Meluncurkan lokal server menggunakan perintah `bun run dev`.
+- Menggunakan curl/Postman dan uji API `POST /api/users/login` dengan mengirimkan email fiktif. Hasil harus merespon HTTP `400`.
+- Kirim kembali menguji kombinasi email registrasi sebelumnya dan *password* yang sah. Hasil seharusnya `200` dengan kembalian berupa `token` dan nama pengguna.

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,9 +1,18 @@
-import { mysqlTable, serial, varchar, timestamp } from "drizzle-orm/mysql-core";
+import { mysqlTable, serial, varchar, timestamp, int, bigint } from "drizzle-orm/mysql-core";
 
 export const users = mysqlTable("users", {
   id: serial("id").primaryKey(),
   name: varchar("name", { length: 255 }).notNull(),
   email: varchar("email", { length: 255 }).notNull().unique(),
   password: varchar("password", { length: 255 }).notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
+export const sessions = mysqlTable("sessions", {
+  id: serial("id").primaryKey(),
+  token: varchar("token", { length: 255 }).notNull(),
+  userId: bigint("user_id", { mode: "number", unsigned: true })
+    .notNull()
+    .references(() => users.id),
   createdAt: timestamp("created_at").defaultNow(),
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ const app = new Elysia()
     status: "ok",
     message: "Welcome to Elysia + Bun + Drizzle + MySQL",
   }))
-  .group("/api", (app) => app.use(usersRoute))
+  .use(usersRoute)
   .listen(3000);
 
 console.log(

--- a/src/routes/users-route.ts
+++ b/src/routes/users-route.ts
@@ -1,7 +1,7 @@
 import { Elysia, t } from "elysia";
 import * as userService from "../services/users-service";
 
-export const usersRoute = new Elysia({ prefix: "/users" }).post(
+export const usersRoute = new Elysia({ prefix: "/api/users" }).post(
   "",
   async ({ body, set }) => {
     try {
@@ -24,6 +24,33 @@ export const usersRoute = new Elysia({ prefix: "/users" }).post(
   {
     body: t.Object({
       name: t.String(),
+      email: t.String(),
+      password: t.String(),
+    }),
+  }
+)
+.post(
+  "/login",
+  async ({ body, set }) => {
+    try {
+      const loginData = await userService.loginUser(body);
+      set.status = 200;
+      return {
+        status: 200,
+        message: "user logged in successfully",
+        data: loginData,
+      };
+    } catch (error: any) {
+      set.status = 400;
+      return {
+        status: 400,
+        message: error.message || "Something went wrong",
+        data: null,
+      };
+    }
+  },
+  {
+    body: t.Object({
       email: t.String(),
       password: t.String(),
     }),

--- a/src/services/users-service.ts
+++ b/src/services/users-service.ts
@@ -1,5 +1,5 @@
 import { db } from "../db";
-import { users } from "../db/schema";
+import { users, sessions } from "../db/schema";
 import { eq } from "drizzle-orm";
 import bcrypt from "bcrypt";
 
@@ -30,5 +30,42 @@ export const registerUser = async (data: any) => {
   return {
     id: result[0].insertId,
     name,
+  };
+};
+
+export const loginUser = async (data: any) => {
+  const { email, password } = data;
+
+  // Find user by email
+  const user = await db
+    .select()
+    .from(users)
+    .where(eq(users.email, email))
+    .limit(1);
+
+  const userData = user[0];
+  if (!userData) {
+    throw new Error("incorrect email or password combination");
+  }
+
+  // Check password
+  const isPasswordValid = await bcrypt.compare(password, userData.password);
+
+  if (!isPasswordValid) {
+    throw new Error("incorrect email or password combination");
+  }
+
+  // Generate token
+  const token = crypto.randomUUID();
+
+  // Create session
+  await db.insert(sessions).values({
+    token,
+    userId: userData.id,
+  });
+
+  return {
+    name: userData.name,
+    token,
   };
 };


### PR DESCRIPTION
## Description
This PR implements user login and session management:
- New `sessions` table to track active user sessions with UUID tokens.
- `loginUser` service with password verification via `bcrypt.compare`.
- `POST /api/users/login` endpoint for user authentication.
- Foreign key connection between `users` and `sessions`.

## Changes
- Updated `src/db/schema.ts` with `sessions` table.
- Added `loginUser` logic to `src/services/users-service.ts`.
- Added `/login` route to `src/routes/users-route.ts`.
- Refined routing in `src/index.ts` for better reliability.
